### PR TITLE
Disable vitest coverage check

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -13,7 +13,8 @@ export default defineConfig({
         coverage: {
             enabled: true,
             // skipFull: true,
-            thresholds: { 100: true },
+            // FIXME: In the future, when we're ready, we should re-enable this threshold check
+            // thresholds: { 100: true },
             include: ['src/**/*.{js,jsx,ts,tsx}'],
         },
     },


### PR DESCRIPTION
For the time being, we're not gating on code coverage, and keeping this check causes CI failures. We can / should enable the threshold check again in the future when we're ready.