### PR TITLE
change how undefined values are handled

### DIFF
--- a/src/lib/aws.test.ts
+++ b/src/lib/aws.test.ts
@@ -150,10 +150,16 @@ describe('getTaskResourcesByRunId', () => {
             ],
             ResourceTypeFilters: ['ecs:task', 'ecs:task-definition'],
         }
-        taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves({})
+
+        const mockResult = {
+            $metadata: {},
+            PaginationToken: '',
+            ResourceTagMappingList: [],
+        }
+        taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves(mockResult)
 
         const res = await getTaskResourcesByRunId(new ResourceGroupsTaggingAPIClient(), 'testrun1234')
-        expect(res).toStrictEqual({})
+        expect(res).toStrictEqual(mockResult)
     })
 })
 
@@ -167,9 +173,14 @@ describe('getAllTaskDefinitionsWithRunId', () => {
             ],
             ResourceTypeFilters: ['ecs:task-definition'],
         }
-        taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves({})
+        const mockResult = {
+            $metadata: {},
+            PaginationToken: '',
+            ResourceTagMappingList: [],
+        }
+        taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves(mockResult)
 
         const res = await getAllTaskDefinitionsWithRunId(new ResourceGroupsTaggingAPIClient())
-        expect(res).toStrictEqual({})
+        expect(res).toStrictEqual(mockResult)
     })
 })

--- a/src/lib/aws.ts
+++ b/src/lib/aws.ts
@@ -135,7 +135,7 @@ export async function runECSFargateTask(
     /* v8 ignore next 3 */
     console.log(
         `AWS:   END: RunTaskCommand finished for tasks`,
-        result.tasks?.map((task) => task),
+        result.tasks?.map((task) => task.taskArn),
     )
     return result
 }

--- a/src/lib/run-studies.test.ts
+++ b/src/lib/run-studies.test.ts
@@ -46,18 +46,20 @@ describe('runStudies()', () => {
 
         // Mock response when querying for a resource with the given run ids
         vi.mocked(aws.getTaskResourcesByRunId).mockImplementation(
-            async (_, runId: string): Promise<GetResourcesCommandOutput> => {
+            async (_, runId: string): Promise<Required<GetResourcesCommandOutput>> => {
                 if (runId === runId_inAWS) {
                     // indicate the run is present
                     return {
                         $metadata: {},
                         ResourceTagMappingList: [{}],
+                        PaginationToken: '',
                     }
                 } else {
                     // indicate there is no resource with the given run ID
                     return {
                         $metadata: {},
                         ResourceTagMappingList: [],
+                        PaginationToken: '',
                     }
                 }
             },
@@ -76,6 +78,7 @@ describe('runStudies()', () => {
                     Tags: [{ Key: RUN_ID_TAG_KEY, Value: runId_toGarbageCollect }],
                 },
             ],
+            PaginationToken: '',
         })
 
         // Mock getECSTaskDefinition

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-    filterManagementAppRuns,
-    filterOrphanTaskDefinitions,
-    ensureValueWithError,
-    ensureValueWithExchange,
-} from '../lib/utils'
+import { filterManagementAppRuns, filterOrphanTaskDefinitions, ensureValueWithError } from '../lib/utils'
 
 describe('filterManagementAppRuns', () => {
     it('filters out runs in the TOA', () => {
@@ -103,24 +98,8 @@ describe('ensureValueWithError', () => {
     })
 
     it('responds with the given error message if values are undefined', () => {
-        expect(() => ensureValueWithError(null, "Can't be null or undefined")).toThrowError(
-            "Can't be null or undefined",
-        )
-        expect(() => ensureValueWithError(undefined)).toThrowError()
-    })
-})
-
-describe('ensureValueWithExchange', () => {
-    it('makes sure values are defined', () => {
-        const myValue: number | undefined = 10
-        expect(ensureValueWithExchange(myValue, 0)).toBe(10)
-    })
-
-    it('exchanges the value if undefined', () => {
-        const myObject: { myStringArray: string[] | undefined; myNumber: number } = {
-            myStringArray: undefined,
-            myNumber: 10,
-        }
-        expect(ensureValueWithExchange(myObject.myStringArray, ['my string'])).toEqual(['my string'])
+        expect(() => ensureValueWithError(null, 'Custom message')).toThrowError('Custom message')
+        expect(() => ensureValueWithError(undefined)).toThrowError('undefined value')
+        expect(() => ensureValueWithError(null)).toThrowError('null value')
     })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -42,12 +42,7 @@ export const filterOrphanTaskDefinitions = (
 // returns given value with type certainty, or errors if value is null or undefined
 export const ensureValueWithError = <T>(value: T | null | undefined, message?: string): T => {
     if (value === null || value === undefined) {
-        throw new Error(message)
+        throw new Error(message || `${value} value`)
     }
     return value
-}
-
-// returns given value with type certainty, or silently exchanges value if null or undefined
-export const ensureValueWithExchange = <T>(value: T | null | undefined, exchange: T): T => {
-    return value || exchange
 }


### PR DESCRIPTION
spun off from #14. AWS API generally seems to return `undefined` only when something has gone wrong, and return an affirmative empty value like `[]` when there is no data.