### PR TITLE
Allow customizing the polling interval

### DIFF
--- a/src/scripts/poll.ts
+++ b/src/scripts/poll.ts
@@ -1,6 +1,12 @@
 import { checkForErroredJobs } from '../lib/check-jobs'
 import { runStudies } from '../lib/run-studies'
 
+const pollStudiesInterval = parseInt(process.env.POLL_STUDIES_INTERVAL_MINUTES || '10')
+const pollForErroredJobsInterval = parseInt(process.env.POLL_ERRORED_JOBS_INTERVAL_MINUTES || '5')
+
+console.log('Polling interval for studies:', pollStudiesInterval)
+console.log('Polling interval for failed jobs:', pollForErroredJobsInterval)
+
 function pollStudies(): void {
     console.log(`Polling management app at ${new Date()}`)
 
@@ -12,9 +18,9 @@ function pollForErroredJobs(): void {
     checkForErroredJobs()
 }
 
-// Poll for studies once now and then every hour (3600000 ms)
+// Poll for studies once now and then 2 minutes by default (for dev)
 pollStudies()
-setInterval(pollStudies, 3600000)
+setInterval(pollStudies, pollStudiesInterval * 60 * 1000)
 
-// Poll for errored tasks every 5 minutes (300000 ms)
-setInterval(pollForErroredJobs, 300000)
+// Poll for errored tasks every 5 minutes by default
+setInterval(pollForErroredJobs, pollForErroredJobsInterval * 60 * 1000)


### PR DESCRIPTION
Set it to 2 minutes by default since we tend to deploy it for testing and do not want to wait an hour