### PR TITLE
Remove study title from task tags

### DIFF
--- a/src/lib/run-studies.ts
+++ b/src/lib/run-studies.ts
@@ -5,7 +5,6 @@ import {
     registerECSTaskDefinition,
     runECSFargateTask,
     JOB_ID_TAG_KEY,
-    TITLE_TAG_KEY,
     getAllTaskDefinitionsWithJobId,
     deleteECSTaskDefinitions,
     getAllTasksWithJobId,
@@ -26,10 +25,8 @@ async function launchStudy(
     imageLocation: string,
     studyTitle: string,
 ): Promise<RunTaskCommandOutput> {
-    const taskTags = [
-        { key: JOB_ID_TAG_KEY, value: jobId },
-        { key: TITLE_TAG_KEY, value: studyTitle },
-    ]
+    console.log(`Creating task definition for study ${studyTitle} and jobId ${jobId}`)
+    const taskTags = [{ key: JOB_ID_TAG_KEY, value: jobId }]
     const baseTaskDefinitionData = await getECSTaskDefinition(client, baseTaskDefinitionFamily)
     baseTaskDefinitionData.taskDefinition = ensureValueWithError(
         baseTaskDefinitionData.taskDefinition,


### PR DESCRIPTION
We may want to revisit this with a fix to sanitize the study title text so it doesn't run up against AWS constraints on tage values, but this is a quick fix to avoid issues for the time being.