### PR TITLE
Remove BMA study fetch when starting poll

### DIFF
--- a/src/scripts/poll.ts
+++ b/src/scripts/poll.ts
@@ -17,8 +17,7 @@ function pollForErroredJobs(): void {
     checkForErroredJobs()
 }
 
-// Poll for studies once now and then 2 minutes by default (for dev)
-pollStudies()
+// Poll for studies every 10 minutes by default (for dev)
 setInterval(pollStudies, pollStudiesInterval * 60 * 1000)
 
 // Poll for errored tasks every 5 minutes by default


### PR DESCRIPTION
We have thus far made a decision that when the SA is unable to access the BMA, it should fail loudly so we get a clear signal in deployments. Unfortunately, in practice it seems that we may lose BMA access in environments for various reasons. This change prevents the SA from cycling rapidly in failures so we can maintain "fail loudly" while avoiding high CPU and costs associated with immediately failing on launch.