### PR TITLE
Sanitize job titles when creating Docker containers and Kubernetes jobs

### DIFF
--- a/src/lib/docker.test.ts
+++ b/src/lib/docker.test.ts
@@ -41,7 +41,7 @@ describe('docker', () => {
             Labels: {
                 app: `research-container-${jobId}`,
                 component: CONTAINER_TYPES.RESEARCH_CONTAINER,
-                'part-of': studyTitle.toLowerCase(),
+                'part-of': 'my_study_title',
                 instance: jobId,
                 'managed-by': CONTAINER_TYPES.SETUP_APP,
             },

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -1,6 +1,6 @@
 import { dockerApiCall } from './api'
 import { CONTAINER_TYPES, DockerApiContainersResponse, DockerApiResponse } from './types'
-import { hasReadPermissions } from './utils'
+import { hasReadPermissions, sanitize } from './utils'
 
 async function pullContainer(imageLocation: string): Promise<DockerApiResponse> {
     const path = `images/create?fromImage=${imageLocation}`
@@ -16,7 +16,7 @@ async function pullContainer(imageLocation: string): Promise<DockerApiResponse> 
 
 function createContainerObject(imageLocation: string, jobId: string, studyTitle: string, toaEndpointWithjobId: string) {
     const name = `research-container-${jobId}`
-    studyTitle = studyTitle.toLowerCase()
+    studyTitle = sanitize(studyTitle.toLowerCase())
     console.log(`Creating Docker container job: ${name}`)
     const container = {
         Image: imageLocation,

--- a/src/lib/kube.test.ts
+++ b/src/lib/kube.test.ts
@@ -77,7 +77,7 @@ describe('Get Service Account items', () => {
                 labels: {
                     app: `research-container-${jobId}`,
                     component: CONTAINER_TYPES.RESEARCH_CONTAINER,
-                    'part-of': studyTitle.toLowerCase(),
+                    'part-of': 'my_study_title',
                     instance: jobId,
                     'managed-by': CONTAINER_TYPES.SETUP_APP,
                 },
@@ -88,7 +88,7 @@ describe('Get Service Account items', () => {
                         labels: {
                             app: `research-container-${jobId}`,
                             component: CONTAINER_TYPES.RESEARCH_CONTAINER,
-                            'part-of': studyTitle.toLowerCase(),
+                            'part-of': 'my_study_title',
                             instance: jobId,
                             'managed-by': CONTAINER_TYPES.SETUP_APP,
                             role: 'toa-access',

--- a/src/lib/kube.ts
+++ b/src/lib/kube.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import https from 'https'
 import tls from 'tls'
 import { CONTAINER_TYPES, KubernetesJob } from './types'
+import { sanitize } from './utils'
 
 export const DEFAULT_SERVICE_ACCOUNT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount'
 
@@ -34,7 +35,7 @@ function initHTTPSTrustStore(): void {
 
 function createKubernetesJob(imageLocation: string, jobId: string, studyTitle: string, toaEndpointWithJobId: string) {
     const name = `research-container-${jobId}`
-    studyTitle = studyTitle.toLowerCase()
+    studyTitle = sanitize(studyTitle.toLowerCase())
     console.log(`Creating Kubernetes job: ${name}`)
     const deployment = {
         apiVersion: 'batch/v1',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
-import { ManagementAppGetReadyStudiesResponse, TOAGetJobsResponse } from './types'
 import { ResourceTagMapping } from '@aws-sdk/client-resource-groups-tagging-api'
-import { JOB_ID_TAG_KEY } from './aws'
 import fs from 'fs'
+import { JOB_ID_TAG_KEY } from './aws'
+import { ManagementAppGetReadyStudiesResponse, TOAGetJobsResponse } from './types'
 
 const getJobIdFromResourceTagMapping = (resource: ResourceTagMapping): string | undefined => {
     return resource.Tags?.find((tag) => tag.Key === JOB_ID_TAG_KEY)?.Value
@@ -74,3 +74,11 @@ export const hasReadPermissions = (
     return hasPermissions
 }
 /* v8 ignore end */
+
+export const sanitize = (input: string): string => {
+    // \w is [A-Za-z0-9_], so anything NOT in that set is a “special” char.
+    // The `g` flag ensures we replace every occurrence.
+    const underscored = input.replace(/[^\w]/g, '_')
+    // collapse multiple underscores into a single one
+    return underscored.replace(/_+/g, '_')
+}


### PR DESCRIPTION
Kubernetes does not allow space in labels. So it was causing a bug when creating pods with job titles containing space or some special characters. 