### PR TITLE
fix task definition not found exception

### DIFF
--- a/src/lib/aws-check-jobs.ts
+++ b/src/lib/aws-check-jobs.ts
@@ -1,9 +1,28 @@
-import { managementAppGetJobStatus, toaSendLogs, toaUpdateJobStatus } from '../lib/api'
-import { describeECSTasks, getAllTasksWithJobId, getLogsForTask, JOB_ID_TAG_KEY } from '../lib/aws'
-import { ensureValueWithError } from '../lib/utils'
+import {
+    managementAppGetJobStatus,
+    managementAppGetReadyStudiesRequest,
+    toaSendLogs,
+    toaUpdateJobStatus,
+} from '../lib/api'
+import {
+    deleteECSTaskDefinitions,
+    describeECSTasks,
+    getAllTasksWithJobId,
+    getLogsForTask,
+    JOB_ID_TAG_KEY,
+} from '../lib/aws'
+import { ensureValueWithError, filterOrphanTaskDefinitions } from '../lib/utils'
 import { ECSClient, TaskStopCode } from '@aws-sdk/client-ecs'
-import { ResourceGroupsTaggingAPIClient } from '@aws-sdk/client-resource-groups-tagging-api'
+import { ResourceGroupsTaggingAPIClient, ResourceTagMapping } from '@aws-sdk/client-resource-groups-tagging-api'
 import 'dotenv/config'
+
+async function cleanupTaskDefs(taskDefsWithJobId: ResourceTagMapping[], ecsClient: ECSClient) {
+    // Garbage collect orphan task definitions
+    const bmaResults = await managementAppGetReadyStudiesRequest()
+    const orphanTaskDefinitions = filterOrphanTaskDefinitions(bmaResults, taskDefsWithJobId)
+    console.log(`Found ${orphanTaskDefinitions.length} orphan task definitions to delete`)
+    await deleteECSTaskDefinitions(ecsClient, orphanTaskDefinitions)
+}
 
 export async function checkForAWSErroredJobs(): Promise<void> {
     /**
@@ -27,11 +46,11 @@ export async function checkForAWSErroredJobs(): Promise<void> {
 
     if (taskArns.length == 0) {
         // There are no tasks to look into
+        cleanupTaskDefs(tasks, ecsClient)
         return
     }
 
     const data = await describeECSTasks(ecsClient, cluster, taskArns)
-
     for (const job of data.tasks ?? []) {
         const maybeJobId = job.tags?.find((tag) => tag.key === JOB_ID_TAG_KEY)?.value
         const jobId = ensureValueWithError(maybeJobId, 'Could not find jobId in task tags')
@@ -70,4 +89,7 @@ export async function checkForAWSErroredJobs(): Promise<void> {
             }
         }
     }
+
+    // Tidy AWS environment
+    cleanupTaskDefs(tasks, ecsClient)
 }

--- a/src/lib/aws-run-studies.test.ts
+++ b/src/lib/aws-run-studies.test.ts
@@ -27,7 +27,6 @@ describe('runStudies()', () => {
         const jobId_inAWS = 'running-in-AWS-env'
         const jobId1 = 'to-be-run-1'
         const jobId2 = 'to-be-run-2'
-        const jobId_toGarbageCollect = 'run-finished'
 
         // mock response from management app
         const mockManagementAppResponse = mockManagementAppResponseGenerator([jobId1, jobId_inTOA, jobId_inAWS, jobId2])
@@ -49,10 +48,6 @@ describe('runStudies()', () => {
             {
                 ResourceARN: jobId_inAWS,
                 Tags: [{ Key: JOB_ID_TAG_KEY, Value: jobId_inAWS }],
-            },
-            {
-                ResourceARN: jobId_toGarbageCollect,
-                Tags: [{ Key: JOB_ID_TAG_KEY, Value: jobId_toGarbageCollect }],
             },
         ])
 
@@ -80,10 +75,6 @@ describe('runStudies()', () => {
     it('makes calls to update the AWS environment (launch studies & garbage collect) as well as TOA', async () => {
         const mockToaUpdateJobStatus = vi.mocked(api.toaUpdateJobStatus)
         await runAWSStudies({ ignoreAWSJobs: false })
-
-        // Make sure calls to delete task definitions were made
-        const deleteECSTaskDefinitionsCalls = vi.mocked(aws.deleteECSTaskDefinitions).mock.calls
-        expect(deleteECSTaskDefinitionsCalls[0][1]).toEqual(['run-finished'])
 
         // Make sure calls to run tasks were made
         const runECSFargateTaskCalls = vi.mocked(aws.runECSFargateTask).mock.calls


### PR DESCRIPTION
Sometimes a task definition would be queried after it was already cleaned up. This didn't happen often but would crash the app when it did. I've moved the cleanup to happen after logs are sent so that the task definition will remain defined until then.