### PR TITLE
use MA URL + member ID to identify enclaves in the same AWS account

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ ECS_CLUSTER='arn:aws:ecs:region:account:cluster/clusterName'
 BASE_TASK_DEFINITION_FAMILY='TaskDefFamiliyName'
 VPC_SUBNETS='subnet-1,subnet-2,subnet-3'
 SECURITY_GROUP='sg-12345'
+# Also tagged onto our AWS resources so enclaves sharing an account don't touch each other's
 MANAGEMENT_APP_BASE_URL='http://localhost:4000'
 MANAGEMENT_APP_MEMBER_ID='openstax'
 MANAGEMENT_APP_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ ECS_CLUSTER='arn:aws:ecs:region:account:cluster/clusterName'
 BASE_TASK_DEFINITION_FAMILY='TaskDefFamiliyName'
 VPC_SUBNETS='subnet-1,subnet-2,subnet-3'
 SECURITY_GROUP='sg-12345'
-# Also tagged onto our AWS resources so enclaves sharing an account don't touch each other's
+# These two are combined and tagged onto our AWS resources so enclaves sharing an account
+# don't touch each other's
 MANAGEMENT_APP_BASE_URL='http://localhost:4000'
 MANAGEMENT_APP_MEMBER_ID='openstax'
 MANAGEMENT_APP_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----

--- a/src/lib/aws-check-jobs.test.ts
+++ b/src/lib/aws-check-jobs.test.ts
@@ -28,6 +28,18 @@ describe('checkForErroredJobs()', () => {
         const deleteECSTaskDefinitionsCalls = vi.mocked(aws.deleteECSTaskDefinitions).mock.calls
         expect(deleteECSTaskDefinitionsCalls[0][1]).toEqual(['run-finished'])
     })
+
+    it('only looks at tasks and task definitions from our own management app', async () => {
+        vi.mocked(aws.getAllTasksWithJobId).mockResolvedValue([])
+
+        await checkForAWSErroredJobs()
+
+        expect(vi.mocked(aws.getAllTasksWithJobId)).toHaveBeenCalledWith(expect.anything(), 'https://bma:12345')
+        expect(vi.mocked(aws.getAllTaskDefinitionsWithJobId)).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://bma:12345',
+        )
+    })
     it('makes call to TOA for task that fails to start', async () => {
         vi.mocked(aws.getAllTasksWithJobId).mockResolvedValue([
             {

--- a/src/lib/aws-check-jobs.test.ts
+++ b/src/lib/aws-check-jobs.test.ts
@@ -34,10 +34,13 @@ describe('checkForErroredJobs()', () => {
 
         await checkForAWSErroredJobs()
 
-        expect(vi.mocked(aws.getAllTasksWithJobId)).toHaveBeenCalledWith(expect.anything(), 'https://bma:12345')
+        expect(vi.mocked(aws.getAllTasksWithJobId)).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://bma:12345=openstax',
+        )
         expect(vi.mocked(aws.getAllTaskDefinitionsWithJobId)).toHaveBeenCalledWith(
             expect.anything(),
-            'https://bma:12345',
+            'https://bma:12345=openstax',
         )
     })
     it('makes call to TOA for task that fails to start', async () => {

--- a/src/lib/aws-check-jobs.ts
+++ b/src/lib/aws-check-jobs.ts
@@ -42,6 +42,7 @@ export async function checkForAWSErroredJobs(): Promise<void> {
     // Only our own enclave's resources are considered; others may share this account
     const managementAppTag = toManagementAppTagValue(
         ensureValueWithError(process.env.MANAGEMENT_APP_BASE_URL, 'Env var MANAGEMENT_APP_BASE_URL not found'),
+        ensureValueWithError(process.env.MANAGEMENT_APP_MEMBER_ID, 'Env var MANAGEMENT_APP_MEMBER_ID not found'),
     )
 
     const tasks = await getAllTasksWithJobId(taggingClient, managementAppTag)

--- a/src/lib/aws-check-jobs.ts
+++ b/src/lib/aws-check-jobs.ts
@@ -12,15 +12,19 @@ import {
     getLogsForTask,
     JOB_ID_TAG_KEY,
 } from '../lib/aws'
-import { ensureValueWithError, filterOrphanTaskDefinitions } from '../lib/utils'
+import { ensureValueWithError, filterOrphanTaskDefinitions, toManagementAppTagValue } from '../lib/utils'
 import { ECSClient, TaskStopCode } from '@aws-sdk/client-ecs'
 import { ResourceGroupsTaggingAPIClient } from '@aws-sdk/client-resource-groups-tagging-api'
 import 'dotenv/config'
 
-async function cleanupTaskDefs(ecsClient: ECSClient, resourceTagClient: ResourceGroupsTaggingAPIClient) {
+async function cleanupTaskDefs(
+    ecsClient: ECSClient,
+    resourceTagClient: ResourceGroupsTaggingAPIClient,
+    managementAppTag: string,
+) {
     // Garbage collect orphan task definitions
     const bmaResults = await managementAppGetReadyStudiesRequest()
-    const taskDefsWithJobId = await getAllTaskDefinitionsWithJobId(resourceTagClient)
+    const taskDefsWithJobId = await getAllTaskDefinitionsWithJobId(resourceTagClient, managementAppTag)
     const orphanTaskDefinitions = filterOrphanTaskDefinitions(bmaResults, taskDefsWithJobId)
     console.log(`Found ${orphanTaskDefinitions.length} orphan task definitions to delete`)
     await deleteECSTaskDefinitions(ecsClient, orphanTaskDefinitions)
@@ -35,8 +39,12 @@ export async function checkForAWSErroredJobs(): Promise<void> {
     const ecsClient = new ECSClient()
     const taggingClient = new ResourceGroupsTaggingAPIClient()
     const cluster = ensureValueWithError(process.env.ECS_CLUSTER, 'Env var ECS_CLUSTER not found')
+    // Only our own enclave's resources are considered; others may share this account
+    const managementAppTag = toManagementAppTagValue(
+        ensureValueWithError(process.env.MANAGEMENT_APP_BASE_URL, 'Env var MANAGEMENT_APP_BASE_URL not found'),
+    )
 
-    const tasks = await getAllTasksWithJobId(taggingClient)
+    const tasks = await getAllTasksWithJobId(taggingClient, managementAppTag)
 
     const taskArns: string[] = []
 
@@ -50,7 +58,7 @@ export async function checkForAWSErroredJobs(): Promise<void> {
 
     if (taskArns.length == 0) {
         // There are no tasks to look into
-        await cleanupTaskDefs(ecsClient, taggingClient)
+        await cleanupTaskDefs(ecsClient, taggingClient, managementAppTag)
         return
     }
 
@@ -95,5 +103,5 @@ export async function checkForAWSErroredJobs(): Promise<void> {
     }
 
     // Tidy AWS environment
-    await cleanupTaskDefs(ecsClient, taggingClient)
+    await cleanupTaskDefs(ecsClient, taggingClient, managementAppTag)
 }

--- a/src/lib/aws-run-studies.test.ts
+++ b/src/lib/aws-run-studies.test.ts
@@ -87,16 +87,19 @@ describe('runStudies()', () => {
         const expectedTags = [
             { key: JOB_ID_TAG_KEY, value: 'to-be-run-1' },
             { key: RESEARCHER_ID_TAG_KEY, value: 'mockResearcherId' },
-            { key: MANAGEMENT_APP_TAG_KEY, value: 'https://bma:12345' },
+            { key: MANAGEMENT_APP_TAG_KEY, value: 'https://bma:12345=openstax' },
         ]
         expect(vi.mocked(aws.registerECSTaskDefinition).mock.calls[0]).toContainEqual(expectedTags)
         expect(runECSFargateTaskCalls[0]).toContainEqual(expectedTags)
 
         // Both lookups are scoped to our own management app
-        expect(vi.mocked(aws.getAllTasksWithJobId)).toHaveBeenCalledWith(expect.anything(), 'https://bma:12345')
+        expect(vi.mocked(aws.getAllTasksWithJobId)).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://bma:12345=openstax',
+        )
         expect(vi.mocked(aws.getAllTaskDefinitionsWithJobId)).toHaveBeenCalledWith(
             expect.anything(),
-            'https://bma:12345',
+            'https://bma:12345=openstax',
         )
         expect(mockToaUpdateJobStatus).toHaveBeenCalledTimes(2)
         expect(mockToaUpdateJobStatus).toHaveBeenNthCalledWith(1, 'to-be-run-1', {

--- a/src/lib/aws-run-studies.test.ts
+++ b/src/lib/aws-run-studies.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as api from './api'
 import * as aws from './aws'
-import { JOB_ID_TAG_KEY } from './aws'
+import { JOB_ID_TAG_KEY, MANAGEMENT_APP_TAG_KEY, RESEARCHER_ID_TAG_KEY } from './aws'
 import { runAWSStudies } from './aws-run-studies'
 import { ManagementAppGetReadyStudiesResponse } from './types'
 
@@ -81,6 +81,23 @@ describe('runStudies()', () => {
         expect(runECSFargateTaskCalls.length).toBe(2)
         expect(runECSFargateTaskCalls[0]).toContain('MOCK_BASE_TASK_DEF_FAMILY-to-be-run-1-registered')
         expect(runECSFargateTaskCalls[1]).toContain('MOCK_BASE_TASK_DEF_FAMILY-to-be-run-2-registered')
+
+        // Both the task definition and the task are tagged with our management app,
+        // which is what scopes the AWS lookups to this enclave
+        const expectedTags = [
+            { key: JOB_ID_TAG_KEY, value: 'to-be-run-1' },
+            { key: RESEARCHER_ID_TAG_KEY, value: 'mockResearcherId' },
+            { key: MANAGEMENT_APP_TAG_KEY, value: 'https://bma:12345' },
+        ]
+        expect(vi.mocked(aws.registerECSTaskDefinition).mock.calls[0]).toContainEqual(expectedTags)
+        expect(runECSFargateTaskCalls[0]).toContainEqual(expectedTags)
+
+        // Both lookups are scoped to our own management app
+        expect(vi.mocked(aws.getAllTasksWithJobId)).toHaveBeenCalledWith(expect.anything(), 'https://bma:12345')
+        expect(vi.mocked(aws.getAllTaskDefinitionsWithJobId)).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://bma:12345',
+        )
         expect(mockToaUpdateJobStatus).toHaveBeenCalledTimes(2)
         expect(mockToaUpdateJobStatus).toHaveBeenNthCalledWith(1, 'to-be-run-1', {
             status: 'JOB-PROVISIONING',

--- a/src/lib/aws-run-studies.ts
+++ b/src/lib/aws-run-studies.ts
@@ -6,10 +6,11 @@ import {
     runECSFargateTask,
     JOB_ID_TAG_KEY,
     RESEARCHER_ID_TAG_KEY,
+    MANAGEMENT_APP_TAG_KEY,
     getAllTaskDefinitionsWithJobId,
     getAllTasksWithJobId,
 } from './aws'
-import { ensureValueWithError, filterManagementAppJobs } from './utils'
+import { ensureValueWithError, filterManagementAppJobs, toManagementAppTagValue } from './utils'
 import { managementAppGetReadyStudiesRequest, toaUpdateJobStatus } from './api'
 import 'dotenv/config'
 import { ManagementAppGetReadyStudiesResponse } from './types'
@@ -18,6 +19,7 @@ async function launchStudy(
     client: ECSClient,
     cluster: string,
     baseTaskDefinitionFamily: string,
+    managementAppTag: string,
     subnets: string[],
     securityGroup: string,
     toaEndpointWithJobId: string,
@@ -30,6 +32,7 @@ async function launchStudy(
     const taskTags = [
         { key: JOB_ID_TAG_KEY, value: jobId },
         { key: RESEARCHER_ID_TAG_KEY, value: researcherId },
+        { key: MANAGEMENT_APP_TAG_KEY, value: managementAppTag },
     ]
     const baseTaskDefinitionData = await getECSTaskDefinition(client, baseTaskDefinitionFamily)
     baseTaskDefinitionData.taskDefinition = ensureValueWithError(
@@ -80,6 +83,10 @@ export async function runAWSStudies(options: { ignoreAWSJobs: boolean }): Promis
     )
     const subnets = ensureValueWithError(process.env.VPC_SUBNETS, 'Env var VPC_SUBNETS not found')
     const securityGroup = ensureValueWithError(process.env.SECURITY_GROUP, 'Env var SECURITY_GROUP not found')
+    // Tags our AWS resources so other enclaves in this account leave them alone
+    const managementAppTag = toManagementAppTagValue(
+        ensureValueWithError(process.env.MANAGEMENT_APP_BASE_URL, 'Env var MANAGEMENT_APP_BASE_URL not found'),
+    )
 
     const bmaReadysResults = await managementAppGetReadyStudiesRequest()
     console.log(
@@ -87,7 +94,7 @@ export async function runAWSStudies(options: { ignoreAWSJobs: boolean }): Promis
     )
 
     // Possibly used in filtering; used in garbage collection
-    const existingAwsTaskDefs = await getAllTaskDefinitionsWithJobId(taggingClient)
+    const existingAwsTaskDefs = await getAllTaskDefinitionsWithJobId(taggingClient, managementAppTag)
     console.log(`Found ${existingAwsTaskDefs.length} task definitions with jobId in the AWS environment`)
 
     let filteredResult: ManagementAppGetReadyStudiesResponse
@@ -97,7 +104,7 @@ export async function runAWSStudies(options: { ignoreAWSJobs: boolean }): Promis
         filteredResult = filterManagementAppJobs(bmaReadysResults)
     } else {
         // Take AWS into account when filtering
-        const existingAwsTasks = await getAllTasksWithJobId(taggingClient)
+        const existingAwsTasks = await getAllTasksWithJobId(taggingClient, managementAppTag)
         console.log(`Found ${existingAwsTasks.length} tasks with jobId in the AWS environment`)
 
         filteredResult = filterManagementAppJobs(bmaReadysResults, existingAwsTasks, existingAwsTaskDefs)
@@ -116,6 +123,7 @@ export async function runAWSStudies(options: { ignoreAWSJobs: boolean }): Promis
             ecsClient,
             cluster,
             baseTaskDefinition,
+            managementAppTag,
             subnets.split(','),
             securityGroup,
             toaEndpointWithJobId,

--- a/src/lib/aws-run-studies.ts
+++ b/src/lib/aws-run-studies.ts
@@ -86,6 +86,7 @@ export async function runAWSStudies(options: { ignoreAWSJobs: boolean }): Promis
     // Tags our AWS resources so other enclaves in this account leave them alone
     const managementAppTag = toManagementAppTagValue(
         ensureValueWithError(process.env.MANAGEMENT_APP_BASE_URL, 'Env var MANAGEMENT_APP_BASE_URL not found'),
+        ensureValueWithError(process.env.MANAGEMENT_APP_MEMBER_ID, 'Env var MANAGEMENT_APP_MEMBER_ID not found'),
     )
 
     const bmaReadysResults = await managementAppGetReadyStudiesRequest()

--- a/src/lib/aws.test.ts
+++ b/src/lib/aws.test.ts
@@ -19,6 +19,7 @@ import {
     registerECSTaskDefinition,
     runECSFargateTask,
     JOB_ID_TAG_KEY,
+    MANAGEMENT_APP_TAG_KEY,
     deleteECSTaskDefinitions,
     getAllTasksWithJobId,
     describeECSTasks,
@@ -199,11 +200,15 @@ describe('getTaskResourcesByJobId', () => {
 })
 
 describe('getAllTaskDefinitionsWithJobId', () => {
-    it('should send GetResourcesCommand and return response', async () => {
+    it('should send GetResourcesCommand scoped to the management app and return response', async () => {
         const expectedCommandInput = {
             TagFilters: [
                 {
                     Key: JOB_ID_TAG_KEY,
+                },
+                {
+                    Key: MANAGEMENT_APP_TAG_KEY,
+                    Values: ['https://testbma:1234'],
                 },
             ],
             ResourceTypeFilters: ['ecs:task-definition'],
@@ -215,7 +220,7 @@ describe('getAllTaskDefinitionsWithJobId', () => {
         }
         taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves(mockResult)
 
-        const res = await getAllTaskDefinitionsWithJobId(new ResourceGroupsTaggingAPIClient())
+        const res = await getAllTaskDefinitionsWithJobId(new ResourceGroupsTaggingAPIClient(), 'https://testbma:1234')
         expect(res).toStrictEqual([])
     })
     it('works for multi page results', async () => {
@@ -223,6 +228,10 @@ describe('getAllTaskDefinitionsWithJobId', () => {
             TagFilters: [
                 {
                     Key: JOB_ID_TAG_KEY,
+                },
+                {
+                    Key: MANAGEMENT_APP_TAG_KEY,
+                    Values: ['https://testbma:1234'],
                 },
             ],
             ResourceTypeFilters: ['ecs:task-definition'],
@@ -242,6 +251,10 @@ describe('getAllTaskDefinitionsWithJobId', () => {
                 {
                     Key: JOB_ID_TAG_KEY,
                 },
+                {
+                    Key: MANAGEMENT_APP_TAG_KEY,
+                    Values: ['https://testbma:1234'],
+                },
             ],
             ResourceTypeFilters: ['ecs:task-definition'],
             PaginationToken: '1',
@@ -256,7 +269,7 @@ describe('getAllTaskDefinitionsWithJobId', () => {
                 },
             ],
         })
-        const res = await getAllTaskDefinitionsWithJobId(new ResourceGroupsTaggingAPIClient())
+        const res = await getAllTaskDefinitionsWithJobId(new ResourceGroupsTaggingAPIClient(), 'https://testbma:1234')
         expect(res).toStrictEqual([
             {
                 ResourceARN: 'arn:1',
@@ -271,11 +284,15 @@ describe('getAllTaskDefinitionsWithJobId', () => {
 })
 
 describe('getAllTasksWithJobId', () => {
-    it('should send GetResourcesCommand and return response', async () => {
+    it('should send GetResourcesCommand scoped to the management app and return response', async () => {
         const expectedCommandInput = {
             TagFilters: [
                 {
                     Key: JOB_ID_TAG_KEY,
+                },
+                {
+                    Key: MANAGEMENT_APP_TAG_KEY,
+                    Values: ['https://testbma:1234'],
                 },
             ],
             ResourceTypeFilters: ['ecs:task'],
@@ -287,7 +304,7 @@ describe('getAllTasksWithJobId', () => {
         }
         taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves(mockResult)
 
-        const res = await getAllTasksWithJobId(new ResourceGroupsTaggingAPIClient())
+        const res = await getAllTasksWithJobId(new ResourceGroupsTaggingAPIClient(), 'https://testbma:1234')
         expect(res).toStrictEqual([])
     })
 })

--- a/src/lib/aws.test.ts
+++ b/src/lib/aws.test.ts
@@ -208,7 +208,7 @@ describe('getAllTaskDefinitionsWithJobId', () => {
                 },
                 {
                     Key: MANAGEMENT_APP_TAG_KEY,
-                    Values: ['https://testbma:1234'],
+                    Values: ['https://testbma:1234=testmember'],
                 },
             ],
             ResourceTypeFilters: ['ecs:task-definition'],
@@ -220,7 +220,10 @@ describe('getAllTaskDefinitionsWithJobId', () => {
         }
         taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves(mockResult)
 
-        const res = await getAllTaskDefinitionsWithJobId(new ResourceGroupsTaggingAPIClient(), 'https://testbma:1234')
+        const res = await getAllTaskDefinitionsWithJobId(
+            new ResourceGroupsTaggingAPIClient(),
+            'https://testbma:1234=testmember',
+        )
         expect(res).toStrictEqual([])
     })
     it('works for multi page results', async () => {
@@ -231,7 +234,7 @@ describe('getAllTaskDefinitionsWithJobId', () => {
                 },
                 {
                     Key: MANAGEMENT_APP_TAG_KEY,
-                    Values: ['https://testbma:1234'],
+                    Values: ['https://testbma:1234=testmember'],
                 },
             ],
             ResourceTypeFilters: ['ecs:task-definition'],
@@ -253,7 +256,7 @@ describe('getAllTaskDefinitionsWithJobId', () => {
                 },
                 {
                     Key: MANAGEMENT_APP_TAG_KEY,
-                    Values: ['https://testbma:1234'],
+                    Values: ['https://testbma:1234=testmember'],
                 },
             ],
             ResourceTypeFilters: ['ecs:task-definition'],
@@ -269,7 +272,10 @@ describe('getAllTaskDefinitionsWithJobId', () => {
                 },
             ],
         })
-        const res = await getAllTaskDefinitionsWithJobId(new ResourceGroupsTaggingAPIClient(), 'https://testbma:1234')
+        const res = await getAllTaskDefinitionsWithJobId(
+            new ResourceGroupsTaggingAPIClient(),
+            'https://testbma:1234=testmember',
+        )
         expect(res).toStrictEqual([
             {
                 ResourceARN: 'arn:1',
@@ -292,7 +298,7 @@ describe('getAllTasksWithJobId', () => {
                 },
                 {
                     Key: MANAGEMENT_APP_TAG_KEY,
-                    Values: ['https://testbma:1234'],
+                    Values: ['https://testbma:1234=testmember'],
                 },
             ],
             ResourceTypeFilters: ['ecs:task'],
@@ -304,7 +310,7 @@ describe('getAllTasksWithJobId', () => {
         }
         taggingMockClient.on(GetResourcesCommand, expectedCommandInput).resolves(mockResult)
 
-        const res = await getAllTasksWithJobId(new ResourceGroupsTaggingAPIClient(), 'https://testbma:1234')
+        const res = await getAllTasksWithJobId(new ResourceGroupsTaggingAPIClient(), 'https://testbma:1234=testmember')
         expect(res).toStrictEqual([])
     })
 })

--- a/src/lib/aws.ts
+++ b/src/lib/aws.ts
@@ -29,6 +29,7 @@ import { ensureValueWithError } from './utils'
 export const JOB_ID_TAG_KEY = 'jobId'
 export const TITLE_TAG_KEY = 'title'
 export const RESEARCHER_ID_TAG_KEY = 'researcherId'
+export const MANAGEMENT_APP_TAG_KEY = 'managementApp'
 
 export type LogEntry = {
     timestamp: number
@@ -221,25 +222,38 @@ export async function getTaskResourcesByJobId(
 
 export async function getAllTaskDefinitionsWithJobId(
     client: ResourceGroupsTaggingAPIClient,
+    managementAppTag: string,
+): Promise<ResourceTagMapping[]> {
+    // Filter on managementAppTag since enclaves can be in the same account
+    const tagFilters = [
+        {
+            Key: JOB_ID_TAG_KEY,
+        },
+        {
+            Key: MANAGEMENT_APP_TAG_KEY,
+            Values: [managementAppTag],
+        },
+    ]
+    const resourceTypeFilters = ['ecs:task-definition']
+    const logMessage = `Getting all task definitions with jobId for management app ${managementAppTag} ...`
+    return await getResourceCommandWrapper(tagFilters, resourceTypeFilters, client, logMessage)
+}
+
+export async function getAllTasksWithJobId(
+    client: ResourceGroupsTaggingAPIClient,
+    managementAppTag: string,
 ): Promise<ResourceTagMapping[]> {
     const tagFilters = [
         {
             Key: JOB_ID_TAG_KEY,
         },
-    ]
-    const resourceTypeFilters = ['ecs:task-definition']
-    const logMessage = 'Getting all task definitions with jobId ...'
-    return await getResourceCommandWrapper(tagFilters, resourceTypeFilters, client, logMessage)
-}
-
-export async function getAllTasksWithJobId(client: ResourceGroupsTaggingAPIClient): Promise<ResourceTagMapping[]> {
-    const tagFilters = [
         {
-            Key: JOB_ID_TAG_KEY,
+            Key: MANAGEMENT_APP_TAG_KEY,
+            Values: [managementAppTag],
         },
     ]
     const resourceTypeFilters = ['ecs:task']
-    const logMessage = 'Getting all tasks with jobId ...'
+    const logMessage = `Getting all tasks with jobId for management app ${managementAppTag} ...`
     return await getResourceCommandWrapper(tagFilters, resourceTypeFilters, client, logMessage)
 }
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -101,24 +101,34 @@ describe('filterOrphanTaskDefinitions', () => {
 })
 
 describe('toManagementAppTagValue', () => {
-    it('leaves a url without a trailing slash alone', () => {
-        expect(toManagementAppTagValue('https://bma:12345')).toBe('https://bma:12345')
+    it('joins the url and the member id', () => {
+        expect(toManagementAppTagValue('https://bma:12345', 'openstax')).toBe('https://bma:12345=openstax')
     })
 
-    it('strips trailing slashes', () => {
-        expect(toManagementAppTagValue('https://bma:12345/')).toBe('https://bma:12345')
-        expect(toManagementAppTagValue('https://bma:12345///')).toBe('https://bma:12345')
+    it('strips trailing slashes from the url', () => {
+        expect(toManagementAppTagValue('https://bma:12345/', 'openstax')).toBe('https://bma:12345=openstax')
+        expect(toManagementAppTagValue('https://bma:12345///', 'openstax')).toBe('https://bma:12345=openstax')
+    })
+
+    it('distinguishes members sharing a management app', () => {
+        expect(toManagementAppTagValue('https://bma:12345', 'member-1')).not.toBe(
+            toManagementAppTagValue('https://bma:12345', 'member-2'),
+        )
     })
 
     it('keeps characters that AWS allows in a tag value', () => {
-        expect(toManagementAppTagValue('https://bma-1.example.com:12345/a_b@c+d=e')).toBe(
-            'https://bma-1.example.com:12345/a_b@c+d=e',
+        expect(toManagementAppTagValue('https://bma-1.example.com:12345/a_b@c+d', 'member.1')).toBe(
+            'https://bma-1.example.com:12345/a_b@c+d=member.1',
         )
     })
 
     it('replaces characters that AWS disallows in a tag value', () => {
-        expect(toManagementAppTagValue('https://bma:12345/x?a=1&b=2')).toBe('https://bma:12345/x_a=1_b=2')
-        expect(toManagementAppTagValue('https://user%name:p^ss@bma#frag')).toBe('https://user_name:p_ss@bma_frag')
+        expect(toManagementAppTagValue('https://bma:12345/x?a=1&b=2', 'openstax')).toBe(
+            'https://bma:12345/x_a=1_b=2=openstax',
+        )
+        expect(toManagementAppTagValue('https://user%name:p^ss@bma#frag', 'mem*ber')).toBe(
+            'https://user_name:p_ss@bma_frag=mem_ber',
+        )
     })
 })
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,12 @@
 import { ResourceTagMapping } from '@aws-sdk/client-resource-groups-tagging-api'
 import { describe, expect, it } from 'vitest'
-import { ensureValueWithError, filterManagementAppJobs, filterOrphanTaskDefinitions, sanitize } from '../lib/utils'
+import {
+    ensureValueWithError,
+    filterManagementAppJobs,
+    filterOrphanTaskDefinitions,
+    toManagementAppTagValue,
+    sanitize,
+} from '../lib/utils'
 import { JOB_ID_TAG_KEY } from './aws'
 
 describe('filterManagementAppJobs', () => {
@@ -91,6 +97,28 @@ describe('filterOrphanTaskDefinitions', () => {
         ]
 
         expect(filterOrphanTaskDefinitions(mockManagementAppResponse, mockTaskDefResources)).toStrictEqual(['arn2'])
+    })
+})
+
+describe('toManagementAppTagValue', () => {
+    it('leaves a url without a trailing slash alone', () => {
+        expect(toManagementAppTagValue('https://bma:12345')).toBe('https://bma:12345')
+    })
+
+    it('strips trailing slashes', () => {
+        expect(toManagementAppTagValue('https://bma:12345/')).toBe('https://bma:12345')
+        expect(toManagementAppTagValue('https://bma:12345///')).toBe('https://bma:12345')
+    })
+
+    it('keeps characters that AWS allows in a tag value', () => {
+        expect(toManagementAppTagValue('https://bma-1.example.com:12345/a_b@c+d=e')).toBe(
+            'https://bma-1.example.com:12345/a_b@c+d=e',
+        )
+    })
+
+    it('replaces characters that AWS disallows in a tag value', () => {
+        expect(toManagementAppTagValue('https://bma:12345/x?a=1&b=2')).toBe('https://bma:12345/x_a=1_b=2')
+        expect(toManagementAppTagValue('https://user%name:p^ss@bma#frag')).toBe('https://user_name:p_ss@bma_frag')
     })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -43,6 +43,12 @@ export const filterOrphanTaskDefinitions = (
     return orphanTaskDefinitions
 }
 
+// Derives an AWS tag value from the management app URL.
+// Remove trailing slash and invalid tag characters
+export const toManagementAppTagValue = (baseUrl: string): string => {
+    return baseUrl.replace(/\/+$/, '').replace(/[^\w +=.:/@-]/g, '_')
+}
+
 // returns given value with type certainty, or errors if value is null or undefined
 export const ensureValueWithError = <T>(value: T | null | undefined, message?: string): T => {
     if (value === null || value === undefined) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -43,10 +43,11 @@ export const filterOrphanTaskDefinitions = (
     return orphanTaskDefinitions
 }
 
-// Derives an AWS tag value from the management app URL.
+// Derives an AWS tag value from the management app URL and member id.
+// The `=` keeps it obvious that this is not a URL, so it is never used to build a request
 // Remove trailing slash and invalid tag characters
-export const toManagementAppTagValue = (baseUrl: string): string => {
-    return baseUrl.replace(/\/+$/, '').replace(/[^\w +=.:/@-]/g, '_')
+export const toManagementAppTagValue = (baseUrl: string, memberId: string): string => {
+    return `${baseUrl.replace(/\/+$/, '')}=${memberId}`.replace(/[^\w +=.:/@-]/g, '_')
 }
 
 // returns given value with type certainty, or errors if value is null or undefined


### PR DESCRIPTION
This adds an AWS tag to task definitions so multiple enclaves can be supported.

The only real changes are
- in [aws.ts](https://github.com/safeinsights/setup-app/pull/61/changes#diff-afaee0f6ab3bdbf8760fefc01dedb65fad6398924a6984416eabb911746f9e72) where we add tags to taskdefs and then filter on them
- in [utils.ts](https://github.com/safeinsights/setup-app/pull/61/changes#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224) where we build the AWS tag to be a sanitiized `<MA_URL>=<MEMBERID>`

The rest of the PR are test changes that funnel the extra fields into the tests